### PR TITLE
Bug/cart duplicate items

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -179,7 +179,7 @@ class Profile(ViewSet):
                     customer=current_user, payment_type=None)
                 line_items = OrderProduct.objects.filter(order=open_order)
                 line_items = LineItemSerializer(
-                     line_items, many=True, context={'request': request})
+                    line_items, many=True, context={'request': request})
 
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -179,12 +179,12 @@ class Profile(ViewSet):
                     customer=current_user, payment_type=None)
                 line_items = OrderProduct.objects.filter(order=open_order)
                 line_items = LineItemSerializer(
-                    line_items, many=True, context={'request': request})
+                     line_items, many=True, context={'request': request})
 
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={
                                                 'request': request}).data
-                cart["order"]["line_items"] = line_items.data
+                """cart["order"]["line_items"] = line_items.data"""
                 cart["order"]["size"] = len(line_items.data)
 
             except Order.DoesNotExist as ex:

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -184,7 +184,6 @@ class Profile(ViewSet):
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={
                                                 'request': request}).data
-                """cart["order"]["line_items"] = line_items.data"""
                 cart["order"]["size"] = len(line_items.data)
 
             except Order.DoesNotExist as ex:


### PR DESCRIPTION
Ticket #36 

Description:
When a client requests the /profile/cart resource, the following two keys are on the response object.

lineitems
line_items
The line_items key needs to be removed from the response.

## Changes

-removed list_items key from response body when requesting /profile/cart


## Testing

Description of how to test code...

- run GET method in postman using /profile/cart (see description above).
