### PR TITLE
bug-fix/all-payments-received-for-every-user

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -79,13 +79,24 @@ class Payments(ViewSet):
 
     def list(self, request):
         """Handle GET requests to payment type resource"""
-        payment_types = Payment.objects.all()
+        #payment_types = Payment.objects.all()
 
-        customer_id = self.request.query_params.get('customer', None)
+        #customer_id = self.request.query_params.get('customer', None)
 
-        if customer_id is not None:
-            payment_types = payment_types.filter(customer__id=customer_id)
+        #if customer_id is not None:
+            #payment_types = payment_types.filter(customer__id=customer_id)
 
+        
+        
+        
+        #Gets the customer object associated with the user making the request
+        customer = Customer.objects.get(user=request.auth.user)
+
+        #Filters the Payment objects to only have those associated with the retrieved customer
+        payment_types = Payment.objects.filter(customer=customer)
+
+
+        
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})
         return Response(serializer.data)


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- In paymenttype.py removed payment.objects.all()
- added customer.objects.get(user=request.auth.user) to get customer objects associated with the user making the request
- added Payment.objects.filter(customer=customer) to filter the returned payment types to only those associated with retrieved customer

