### PR TITLE
Updated delete lineitem from cart

### DIFF
--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -62,7 +62,7 @@ class LineItems(ViewSet):
 
     def destroy(self, request, pk=None):
         """
-        @api {DELETE} /cart/:id DELETE line item from cart
+        @api {DELETE} /lineitems/:id DELETE line item from cart
         @apiName RemoveLineItem
         @apiGroup ShoppingCart
 


### PR DESCRIPTION
After realizing that the user couldn't delete the item in the browser, I updated the logic to ensure the front end worked with the backend. While doing so, I realized that the application was deleting line items based off their product Id which was inappropriate because there may be two items in the cart that have the same product Id (two of the same item in the cart). As a result, I changed the logic in that the item would be deleted based off the lineitemId instead.

## Changes

-I didn't change any code in this commit, just a comment for what someone reading the logic should use to test the code in postman.


## Requests / Responses

**Request**

DELETE `/lineitem/n` Deletes product from cart based off lineitem Id

**Response**

HTTP/1.1 200 OK, no response body


## Testing


IN POSTMAN
- [ ] POST `profile/cart` Add item to cart using request body below:
```
    {
        "product_id": 15
    }
```
- [ ] GET `profile/cart` to see all items in cart, pick an item to delete.
- [ ] DELETE `lineitems/n` delete lineitem based off LINEITEM ID
- [ ] GET `profile/cart` to verify selected item was deleted


