### PR TITLE
Feature: Increase maximum possible price #25

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -272,6 +272,8 @@ class Products(ViewSet):
         order = self.request.query_params.get("order_by", None)
         direction = self.request.query_params.get("direction", None)
         number_sold = self.request.query_params.get("number_sold", None)
+        min_price = self.request.query_params.get("min_price", None)
+        max_price = self.request.query_params.get("max_price", None)
 
         if order is not None:
             order_filter = order
@@ -297,6 +299,22 @@ class Products(ViewSet):
 
             products = filter(sold_filter, products)
 
+        if min_price is not None:
+            def min_price_filter(product):
+                if product.price >= int(min_price):
+                    return True
+                return False
+
+            products = filter(min_price_filter, products)
+
+        if max_price is not None:
+            def max_price_filter(product):
+                if product.price <= int(max_price):
+                    return True
+                return False
+
+            products = filter(max_price_filter, products)
+
         serializer = ProductSerializer(
             products, many=True, context={"request": request}
         )
@@ -317,3 +335,4 @@ class Products(ViewSet):
             return Response(None, status=status.HTTP_204_NO_CONTENT)
 
         return Response(None, status=status.HTTP_405_METHOD_NOT_ALLOWED)
+


### PR DESCRIPTION
##Description
Accommodating the need to allow higher-priced products in the system, I updated the logic to increase the maximum allowed price from $10,000 to $17,500. This ensures that users can add more expensive products without being rejected by the system. I also add some logic that prevented products over $17,500 from being added

## Changes

- Updated the Product model to increase the maximum price validation to $17,500
- Added validation in the ProductSerializer to ensure the new maximum price limit is respected



**Request**

POST `/products` Creates a new product

```json
{
    "name": "Rolex Watch",
    "price": 17500.00,
    "description": "A high-end luxury watch.",
    "quantity": 10,
    "location": "New York",
    "category_id": 2
}

```

**Response**

HTTP/1.1 201 Created

```json
{
    "name": "Rolex Watch",
    "price": 17500.0,
    "description": "A high-end luxury watch.",
    "quantity": 10,
    "location": "New York",
    "image_path": null
}
```
Next is Request and Response for product over the price threshold.

**Request**
{
    "name": "More Expensive Rolex Watch",
    "price": 17501.00,
    "description": "A high-end luxury watch.",
    "quantity": 10,
    "location": "New York",
    "category_id": 2
}

**Response**
{
    "price": [
        "Ensure this value is less than or equal to 17500.0."
    ]
}
## Testing

Description of how to test code...

- [ ] Run a POSTMAN request for POST on a product under the $17,500 threshold. Check results.
- [ ] Run a POSTMAN request for POST on a product over the $17,500 threshold. Check results.



