### PR TITLE
Feature: get products by location

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -274,15 +274,16 @@ class Products(ViewSet):
         number_sold = self.request.query_params.get("number_sold", None)
         min_price = self.request.query_params.get("min_price", None)
         max_price = self.request.query_params.get("max_price", None)
+        location = self.request.query_params.get("location", None)
 
         if order is not None:
             order_filter = order
 
-            if direction is not None:
-                if direction == "desc":
-                    order_filter = f"-{order}"
+        if direction is not None:
+            if direction == "desc":
+                order_filter = f"-{order}"
 
-            products = products.order_by(order_filter)
+                products = products.order_by(order_filter)
 
         if category is not None:
             products = products.filter(category__id=category)
@@ -314,6 +315,9 @@ class Products(ViewSet):
                 return False
 
             products = filter(max_price_filter, products)
+
+        if location is not None:
+            products = products.filter(location__contains=location)
 
         serializer = ProductSerializer(
             products, many=True, context={"request": request}


### PR DESCRIPTION
When the client performs a GET request to the products resource, a query string parameter of location should be supported to get all products whose location property contains the value of the query string parameter.

Ticket #24 

## Changes

- updated query parameters within products view to include location
- updated if statement formatting for queries

## Requests / Responses

**Request**

GET `/products` Gets a list of ALL products
GET `/products?location=x` Gets a list of products for location x


**Response**

HTTP/1.1 200 OK

EXAMPLE if paris is used instead of x
```json
[
    {
        "id": 2,
        "name": "Golf",
        "price": 653.59,
        "number_sold": 0,
        "description": "1994 Volkswagen",
        "quantity": 4,
        "created_date": "2019-07-10",
        "location": "Paris",
        "image_path": "http://localhost:8000/media/products/vehicle.png",
        "average_rating": 0
    },
    {
        "id": 4,
        "name": "Golf",
        "price": 653.59,
        "number_sold": 0,
        "description": "1994 Volkswagen",
        "quantity": 4,
        "created_date": "2019-07-10",
        "location": "Paris",
        "image_path": "http://localhost:8000/media/products/vehicle.png",
        "average_rating": 0
    }
]
```

## Testing

Description of how to test code...

- [ ] GET `/products?location=paris` Gets you an array of objects for that location
- [ ] Run previous request with other locations in database to test

